### PR TITLE
Reduce whitespace imageviewer-screen

### DIFF
--- a/Sunlit/Storyboards/ImageViewer.storyboard
+++ b/Sunlit/Storyboards/ImageViewer.storyboard
@@ -116,7 +116,7 @@
                                 <rect key="frame" x="0.0" y="638.5" width="414" height="257.5"/>
                                 <subviews>
                                     <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" bounces="NO" scrollEnabled="NO" showsHorizontalScrollIndicator="NO" showsVerticalScrollIndicator="NO" bouncesZoom="NO" editable="NO" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="IkF-my-QPK">
-                                        <rect key="frame" x="8" y="4" width="398" height="183.5"/>
+                                        <rect key="frame" x="8" y="4" width="398" height="166.5"/>
                                         <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         <string key="text">Lorem ipsum dolor sit er elit lamet, consectetaur cillium adipisicing pecu, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Nam liber te conscient to factor tum poen legum odioque civiuda.</string>
                                         <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
@@ -125,7 +125,7 @@
                                         <dataDetectorType key="dataDetectorTypes" phoneNumber="YES" link="YES" calendarEvent="YES"/>
                                     </textView>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="GA5-FZ-zm6">
-                                        <rect key="frame" x="368" y="202.5" width="30" height="30"/>
+                                        <rect key="frame" x="368" y="185.5" width="30" height="30"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="30" id="ib8-l8-GmB"/>
                                             <constraint firstAttribute="width" constant="30" id="oN7-uz-pYA"/>
@@ -139,7 +139,7 @@
                                         </connections>
                                     </button>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Ygh-do-vOV">
-                                        <rect key="frame" x="16" y="202.5" width="30" height="30"/>
+                                        <rect key="frame" x="16" y="185.5" width="30" height="30"/>
                                         <constraints>
                                             <constraint firstAttribute="width" constant="30" id="1jj-UI-WW1"/>
                                             <constraint firstAttribute="height" constant="30" id="TaU-dX-7He"/>
@@ -153,14 +153,14 @@
                                         </connections>
                                     </button>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="5I1-9N-8r7">
-                                        <rect key="frame" x="0.0" y="193.5" width="414" height="0.5"/>
+                                        <rect key="frame" x="0.0" y="176.5" width="414" height="0.5"/>
                                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="0.14810051489128637" colorSpace="custom" customColorSpace="displayP3"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="0.5" id="1Cx-2W-z6C"/>
                                         </constraints>
                                     </view>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="bZS-Di-PGx">
-                                        <rect key="frame" x="192" y="202.5" width="30" height="30"/>
+                                        <rect key="frame" x="192" y="185.5" width="30" height="30"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="30" id="7d2-pq-V5Z"/>
                                             <constraint firstAttribute="width" constant="30" id="vnD-DS-y6M"/>
@@ -177,18 +177,17 @@
                                 <color key="backgroundColor" white="0.25217319539999999" alpha="0.79891065139999995" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <constraints>
                                     <constraint firstItem="Ygh-do-vOV" firstAttribute="leading" secondItem="h4w-xl-KHa" secondAttribute="leading" constant="16" id="288-IW-sBd"/>
+                                    <constraint firstItem="GA5-FZ-zm6" firstAttribute="top" secondItem="IkF-my-QPK" secondAttribute="bottom" constant="15" id="3Mp-TA-nfC"/>
                                     <constraint firstAttribute="trailing" secondItem="IkF-my-QPK" secondAttribute="trailing" constant="8" id="4Qh-ki-2yv"/>
                                     <constraint firstItem="5I1-9N-8r7" firstAttribute="top" secondItem="IkF-my-QPK" secondAttribute="bottom" constant="6" id="7Mv-db-ChQ"/>
-                                    <constraint firstAttribute="bottom" secondItem="bZS-Di-PGx" secondAttribute="bottom" constant="25" id="Dsr-wL-mOa"/>
-                                    <constraint firstAttribute="bottom" secondItem="Ygh-do-vOV" secondAttribute="bottom" constant="25" id="L1i-j9-nrW"/>
+                                    <constraint firstItem="bZS-Di-PGx" firstAttribute="top" secondItem="IkF-my-QPK" secondAttribute="bottom" constant="15" id="Q1D-q1-ZlX"/>
                                     <constraint firstAttribute="trailing" secondItem="GA5-FZ-zm6" secondAttribute="trailing" constant="16" id="TKc-8S-sGa"/>
                                     <constraint firstAttribute="trailing" secondItem="5I1-9N-8r7" secondAttribute="trailing" id="cPY-vd-J4z"/>
-                                    <constraint firstAttribute="bottom" secondItem="IkF-my-QPK" secondAttribute="bottom" constant="70" id="cgF-UG-gqG"/>
                                     <constraint firstItem="IkF-my-QPK" firstAttribute="leading" secondItem="h4w-xl-KHa" secondAttribute="leading" constant="8" id="ety-WH-o7B"/>
                                     <constraint firstItem="bZS-Di-PGx" firstAttribute="centerX" secondItem="h4w-xl-KHa" secondAttribute="centerX" id="mkd-cP-id0"/>
                                     <constraint firstItem="5I1-9N-8r7" firstAttribute="leading" secondItem="h4w-xl-KHa" secondAttribute="leading" id="oKe-Oa-AeM"/>
-                                    <constraint firstAttribute="bottom" secondItem="GA5-FZ-zm6" secondAttribute="bottom" constant="25" id="pay-Bv-Yb4"/>
                                     <constraint firstItem="IkF-my-QPK" firstAttribute="top" secondItem="h4w-xl-KHa" secondAttribute="top" constant="4" id="rO3-6V-0l0"/>
+                                    <constraint firstItem="Ygh-do-vOV" firstAttribute="top" secondItem="IkF-my-QPK" secondAttribute="bottom" constant="15" id="trb-9c-txy"/>
                                 </constraints>
                             </view>
                         </subviews>
@@ -202,6 +201,7 @@
                             <constraint firstItem="FVq-VH-8Ql" firstAttribute="top" secondItem="D0c-HF-hM6" secondAttribute="top" id="YUS-lc-XY9"/>
                             <constraint firstItem="h4w-xl-KHa" firstAttribute="trailing" secondItem="D0c-HF-hM6" secondAttribute="trailing" id="cI0-Si-KZi"/>
                             <constraint firstItem="FVq-VH-8Ql" firstAttribute="trailing" secondItem="D0c-HF-hM6" secondAttribute="trailing" id="fEN-Wt-GG2"/>
+                            <constraint firstItem="D0c-HF-hM6" firstAttribute="bottom" secondItem="bZS-Di-PGx" secondAttribute="bottom" constant="8" id="kjU-cq-o92"/>
                             <constraint firstItem="FVq-VH-8Ql" firstAttribute="leading" secondItem="D0c-HF-hM6" secondAttribute="leading" id="m7D-Ts-yL1"/>
                             <constraint firstItem="40L-Qi-E5N" firstAttribute="leading" secondItem="D0c-HF-hM6" secondAttribute="leading" id="nSj-iw-0Ne"/>
                             <constraint firstItem="40L-Qi-E5N" firstAttribute="top" secondItem="TnI-e9-vIF" secondAttribute="top" id="oLw-6X-0h8"/>
@@ -228,7 +228,7 @@
         <image name="bubble.left.and.bubble.right" catalog="system" width="128" height="96"/>
         <image name="safari" catalog="system" width="128" height="121"/>
         <image name="square.and.arrow.up" catalog="system" width="115" height="128"/>
-        <image name="trash" catalog="system" width="118" height="128"/>
+        <image name="trash" catalog="system" width="121" height="128"/>
         <image name="xmark" catalog="system" width="128" height="113"/>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>


### PR DESCRIPTION
Hi there,

a few days ago I noticed that the new Main-Screen on Sunlit 3.0 had a white bar at the bottom on iPhones with a Homebutton. So I asked for [help](https://micro.blog/zeitschlag/10232746) and as far as I can tell, you folks already fixed the issue before I found out about Sunlit being open source today. (Sidenote: It's so awesome, that Sunlit is open source. Thank you so much!) 

Nevertheless, I wanted to have a look at the app and found out, that the bar at the bottom appears on other screens as well. This PR offers a fix for the ImageViewer. It looks good now on iPhones with a home button and with a home indicator.