### PR TITLE
Reduce whitespace on conversation-screen

### DIFF
--- a/Sunlit/Source/ViewControllers/ConversationViewController.swift
+++ b/Sunlit/Source/ViewControllers/ConversationViewController.swift
@@ -195,7 +195,8 @@ class ConversationViewController: UIViewController {
 				}
 
 				UIView.animate(withDuration: 0.25) {
-					self.replyContainerBottomConstraint.constant = frame.size.height  - 20.0//+ self.view.safeAreaInsets.bottom
+					self.replyTextfieldBottomMarginConstraint.isActive = false
+					self.replyContainerBottomConstraint.constant = frame.size.height
 					self.postButton.alpha = 1.0
 					self.view.layoutIfNeeded()
 					self.replyFieldPlaceholder.alpha = 0.0
@@ -209,6 +210,7 @@ class ConversationViewController: UIViewController {
 				
 			UIView.animate(withDuration: 0.25) {
 				self.replyContainerBottomConstraint.constant = 0
+				self.replyTextfieldBottomMarginConstraint.isActive = true
 				//self.tableBottomConstraint.constant = 44
 				self.postButton.alpha = 0.0
 				self.view.layoutIfNeeded()

--- a/Sunlit/Source/ViewControllers/ConversationViewController.swift
+++ b/Sunlit/Source/ViewControllers/ConversationViewController.swift
@@ -61,7 +61,6 @@ class ConversationViewController: UIViewController {
 		let iPhoneWithHomeIndicatorBottomMargin: CGFloat = -2
 		let iPadWithHomeIndicatorBottomMargin: CGFloat = 0
 
-		// iPhone with Home-Button vs. iPhone with Home-Indicator
 		if self.view.safeAreaInsets.bottom > 0 {
 			if UIDevice.current.userInterfaceIdiom == .pad {
 				self.replyTextfieldBottomMarginConstraint.constant = iPadWithHomeIndicatorBottomMargin

--- a/Sunlit/Source/ViewControllers/ConversationViewController.swift
+++ b/Sunlit/Source/ViewControllers/ConversationViewController.swift
@@ -22,7 +22,8 @@ class ConversationViewController: UIViewController {
 	@IBOutlet var replyingToButton : UIButton!
 
 	@IBOutlet var replyContainerBottomConstraint : NSLayoutConstraint!
-	
+	@IBOutlet var replyTextfieldBottomMarginConstraint: NSLayoutConstraint!
+
 	var posts : [SunlitPost] = []
 	var allUsers : Set<String> = []
 	var selectedUsers : Set<String> = []
@@ -42,7 +43,6 @@ class ConversationViewController: UIViewController {
 		self.setupTable()
 		self.setupNavigation()
 		self.setupGesture()
-
     }
 	
 	override func viewWillAppear(_ animated: Bool) {
@@ -52,6 +52,19 @@ class ConversationViewController: UIViewController {
 
 		self.setupNotifications()
 		self.spinner.startAnimating()
+	}
+
+	override func viewDidLayoutSubviews() {
+		super.viewDidLayoutSubviews()
+
+		// iPhone with Home-Button vs. iPhone with Home-Indicator
+		if self.view.safeAreaInsets.bottom > 0 {
+			// set constant to -2
+			self.replyTextfieldBottomMarginConstraint.constant = -2
+		} else {
+			self.replyTextfieldBottomMarginConstraint.constant = 8
+		}
+
 	}
 	
 	override func viewWillDisappear(_ animated: Bool) {

--- a/Sunlit/Source/ViewControllers/ConversationViewController.swift
+++ b/Sunlit/Source/ViewControllers/ConversationViewController.swift
@@ -57,14 +57,20 @@ class ConversationViewController: UIViewController {
 	override func viewDidLayoutSubviews() {
 		super.viewDidLayoutSubviews()
 
+		let deviceWithHomeButtonBottomMargin: CGFloat = 8
+		let iPhoneWithHomeIndicatorBottomMargin: CGFloat = -2
+		let iPadWithHomeIndicatorBottomMargin: CGFloat = 0
+
 		// iPhone with Home-Button vs. iPhone with Home-Indicator
 		if self.view.safeAreaInsets.bottom > 0 {
-			// set constant to -2
-			self.replyTextfieldBottomMarginConstraint.constant = -2
+			if UIDevice.current.userInterfaceIdiom == .pad {
+				self.replyTextfieldBottomMarginConstraint.constant = iPadWithHomeIndicatorBottomMargin
+			} else {
+				self.replyTextfieldBottomMarginConstraint.constant = iPhoneWithHomeIndicatorBottomMargin
+			}
 		} else {
-			self.replyTextfieldBottomMarginConstraint.constant = 8
+			self.replyTextfieldBottomMarginConstraint.constant = deviceWithHomeButtonBottomMargin
 		}
-
 	}
 	
 	override func viewWillDisappear(_ animated: Bool) {

--- a/Sunlit/Storyboards/Conversation.storyboard
+++ b/Sunlit/Storyboards/Conversation.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17154" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="0np-If-1rf">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17156" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="0np-If-1rf">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17124"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17125"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
@@ -161,7 +161,7 @@
                                 </connections>
                             </tableView>
                             <view clipsSubviews="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="yzi-09-OSy">
-                                <rect key="frame" x="0.0" y="818" width="414" height="78"/>
+                                <rect key="frame" x="0.0" y="808" width="414" height="88"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="goW-pK-Jfh">
                                         <rect key="frame" x="0.0" y="0.0" width="414" height="0.5"/>
@@ -229,9 +229,9 @@
                                 <constraints>
                                     <constraint firstItem="goW-pK-Jfh" firstAttribute="leading" secondItem="yzi-09-OSy" secondAttribute="leading" id="36S-Ij-B0s"/>
                                     <constraint firstItem="vpU-s5-4V2" firstAttribute="leading" secondItem="yzi-09-OSy" secondAttribute="leading" constant="12" id="CmZ-HA-Ykv"/>
+                                    <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="vpU-s5-4V2" secondAttribute="bottom" constant="8" id="Ikg-I9-XWU"/>
                                     <constraint firstAttribute="trailing" secondItem="vpU-s5-4V2" secondAttribute="trailing" constant="12" id="Jeb-z7-YKo"/>
                                     <constraint firstItem="8Td-Zo-NLB" firstAttribute="trailing" secondItem="vpU-s5-4V2" secondAttribute="trailing" constant="-12" id="TAx-jK-Bsb"/>
-                                    <constraint firstAttribute="bottom" secondItem="vpU-s5-4V2" secondAttribute="bottom" constant="32" id="WPk-Gs-bYF"/>
                                     <constraint firstAttribute="trailing" secondItem="goW-pK-Jfh" secondAttribute="trailing" id="Xoo-jc-fg5"/>
                                     <constraint firstItem="vpU-s5-4V2" firstAttribute="top" secondItem="yzi-09-OSy" secondAttribute="top" constant="8" id="Y3S-pi-exC"/>
                                     <constraint firstItem="goW-pK-Jfh" firstAttribute="top" secondItem="yzi-09-OSy" secondAttribute="top" id="b7i-le-T9T"/>
@@ -242,7 +242,7 @@
                                 <rect key="frame" x="188.5" y="429.5" width="37" height="37"/>
                             </activityIndicatorView>
                             <view hidden="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="MnN-6C-PLH">
-                                <rect key="frame" x="0.0" y="774" width="414" height="44"/>
+                                <rect key="frame" x="0.0" y="764" width="414" height="44"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="1bu-cF-87y">
                                         <rect key="frame" x="0.0" y="0.0" width="414" height="0.5"/>
@@ -286,6 +286,7 @@
                             <constraint firstItem="qSu-Ay-kLS" firstAttribute="bottom" secondItem="c1a-0P-ojR" secondAttribute="bottom" constant="44" id="glB-HS-n6Z"/>
                             <constraint firstItem="MnN-6C-PLH" firstAttribute="trailing" secondItem="qSu-Ay-kLS" secondAttribute="trailing" id="kOK-id-yQ8"/>
                             <constraint firstAttribute="bottom" secondItem="yzi-09-OSy" secondAttribute="bottom" id="ozQ-cf-YBw"/>
+                            <constraint firstItem="qSu-Ay-kLS" firstAttribute="bottom" secondItem="vpU-s5-4V2" secondAttribute="bottom" constant="8" id="sON-ok-1r0"/>
                             <constraint firstItem="qSu-Ay-kLS" firstAttribute="trailing" secondItem="yzi-09-OSy" secondAttribute="trailing" id="uCd-MD-jNy"/>
                         </constraints>
                     </view>
@@ -295,6 +296,7 @@
                         <outlet property="replyContainerBottomConstraint" destination="ozQ-cf-YBw" id="MiG-AT-jPS"/>
                         <outlet property="replyField" destination="fge-xx-GRZ" id="Z1O-uV-kj0"/>
                         <outlet property="replyFieldPlaceholder" destination="jHc-xR-l5T" id="B2C-fX-FLM"/>
+                        <outlet property="replyTextfieldBottomMarginConstraint" destination="sON-ok-1r0" id="q9b-r3-SmK"/>
                         <outlet property="replyingToButton" destination="Xdz-Jq-HIy" id="pbg-cp-Ivi"/>
                         <outlet property="replyingToContainer" destination="MnN-6C-PLH" id="XDu-OS-4ZI"/>
                         <outlet property="spinner" destination="GFK-dA-9Rj" id="jG3-2b-NHE"/>


### PR DESCRIPTION
As I mentioned in my [previous PR](https://github.com/microdotblog/sunlit/pull/110), there was some whitespace at the bottom of the conversation-screen on iPhones and iPads with a Home-Button. This PR suggests a fix so that it looks better on all devices (On iPhones with a Home Indicator, there shouldn't be a difference :D). As an example, here's the screen of an iPhone SE before and after these changes:

![iPhone_SE_Conversation_Screen](https://user-images.githubusercontent.com/2580019/94204180-11dc1280-fec1-11ea-8001-966a9619217c.png)

On iPad, it looked pretty much the same before: A high margin below the comment-field. Due to laziness-reasons, I only provide screenshot of the final version so you can see how it looks like on iPads with and without a Home-Button now:

![Simulator Screen Shot - iPad (8th generation) - 2020-09-24 at 23 49 24](https://user-images.githubusercontent.com/2580019/94204242-2a4c2d00-fec1-11ea-87ac-2e7aef206070.png)

![Simulator Screen Shot - iPad Air (4th generation) - 2020-09-24 at 23 52 19](https://user-images.githubusercontent.com/2580019/94204232-26b8a600-fec1-11ea-8bb7-9fb53f69e547.png)

I also considered the keyboard on all devices (also: I'm lazy, so just one screenshot):

![Simulator Screen Shot - iPad Air (4th generation) - 2020-09-24 at 23 52 05](https://user-images.githubusercontent.com/2580019/94204328-57004480-fec1-11ea-9a1f-4ad174a9b95e.png)

Please feel free to review the code and merge this PR if you are happy with it. If you request any changes, just say something 🙂 I'm looking forward to reading your comments.