### PR TITLE
Use a unique UUID-derived filename for image and movie uploads to micropub endpoints

### DIFF
--- a/Libraries/Snippets/Snippets+Micropub.swift
+++ b/Libraries/Snippets/Snippets+Micropub.swift
@@ -207,6 +207,7 @@ extension Snippets {
             var formData : Data = Data()
             let imageName = "file"
             let boundary = ProcessInfo.processInfo.globallyUniqueString
+            let filename = UUID().uuidString.replacingOccurrences(of: "-", with: "") + ".jpg"
 
             if let blogUid = identity.micropubUid {
                 if blogUid.count > 0 {
@@ -217,7 +218,7 @@ extension Snippets {
             }
             
             formData.append(String("--\(boundary)\r\n").data(using: String.Encoding.utf8)!)
-            formData.append(String("Content-Disposition: form-data; name=\"\(imageName)\"; filename=\"image.jpg\"\r\n").data(using: String.Encoding.utf8)!)
+            formData.append(String("Content-Disposition: form-data; name=\"\(imageName)\"; filename=\"\(filename)\r\n").data(using: String.Encoding.utf8)!)
             formData.append(String("Content-Type: image/jpeg\r\n\r\n").data(using: String.Encoding.utf8)!)
             formData.append(imageData)
             formData.append(String("\r\n").data(using: String.Encoding.utf8)!)
@@ -245,6 +246,7 @@ extension Snippets {
             var formData : Data = Data()
             let imageName = "file"
             let boundary = ProcessInfo.processInfo.globallyUniqueString
+            let filename = UUID().uuidString.replacingOccurrences(of: "-", with: "") + ".mov"
                     
             if let blogUid = identity.micropubUid {
                 if blogUid.count > 0 {
@@ -255,7 +257,7 @@ extension Snippets {
             }
             
             formData.append(String("--\(boundary)\r\n").data(using: String.Encoding.utf8)!)
-            formData.append(String("Content-Disposition: form-data; name=\"\(imageName)\"; filename=\"video.mov\"\r\n").data(using: String.Encoding.utf8)!)
+            formData.append(String("Content-Disposition: form-data; name=\"\(imageName)\"; filename=\"\(filename)\"\r\n").data(using: String.Encoding.utf8)!)
             formData.append(String("Content-Type: video/mov\r\n\r\n").data(using: String.Encoding.utf8)!)
             formData.append(data)
             formData.append(String("\r\n").data(using: String.Encoding.utf8)!)


### PR DESCRIPTION
Whilst experimenting with Sunlit, I noticed that image and movie uploads to an external micropub endpoint always use the filename: `image.jpg` and `movie.mov` respectively.

On examining the source, I noticed that uploads to XMLRPC endpoints however don't and instead use a UUID-derived filename:

https://github.com/microdotblog/sunlit/blob/65567259f39b4739e1e80e40b3195aeaf426f9a4/Libraries/Snippets/Snippets%2BXMLRPC.swift#L158

https://github.com/microdotblog/sunlit/blob/65567259f39b4739e1e80e40b3195aeaf426f9a4/Libraries/Snippets/Snippets%2BXMLRPC.swift#L205

This PR implements the same logic for micropub image and movie uploads.

Note: this PR targets the `3.2` branch as I believe `master` represents the current stable 3.0 release. I can re-target if you'd prefer this to target `master`.

Fixes https://github.com/microdotblog/sunlit/issues/131