### PR TITLE
Fix to set alt text on the media item

### DIFF
--- a/Sunlit/Source/ViewControllers/AltTextController.swift
+++ b/Sunlit/Source/ViewControllers/AltTextController.swift
@@ -10,12 +10,18 @@ import UIKit
 
 class AltTextController: UIViewController {
 
-	@IBOutlet var altTextDialogView : UIView!
-	@IBOutlet var altTextTextView : UITextView!
-	@IBOutlet var altTextCancelButton : UIButton!
-	@IBOutlet var altTextDoneButton : UIButton!
+    @IBOutlet var altTextTextView : UITextView!
+    var media : SunlitMedia?
+
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+
+        altTextTextView.text = media?.altText
+        altTextTextView.becomeFirstResponder()
+    }
 
 	@IBAction func done() {
+        media?.altText = altTextTextView.text
 		self.presentingViewController?.dismiss(animated: true)
 	}
 

--- a/Sunlit/Source/ViewControllers/ComposeViewController.swift
+++ b/Sunlit/Source/ViewControllers/ComposeViewController.swift
@@ -23,13 +23,6 @@ class ComposeViewController: UIViewController {
 	@IBOutlet var keyboardAccessoryViewBottomConstraint : NSLayoutConstraint!
 	@IBOutlet var blogSelectorButton : UIButton!
 
-    @IBOutlet var altTextDialogView : UIView!
-    @IBOutlet var altTextTextView : UITextView!
-    @IBOutlet var altTextCancelButton : UIButton!
-    @IBOutlet var altTextDoneButton : UIButton!
-    var altTextSection : SunlitComposition? = nil
-    var altTextItem : Int = 0
-
 	var sections : [SunlitComposition] = []
 	var textViewDictionary : [UITextView : SunlitComposition] = [ : ]
 	var needsInitialFirstResponder = true
@@ -316,56 +309,9 @@ class ComposeViewController: UIViewController {
 
 		let storyboard: UIStoryboard = UIStoryboard(name: "Compose", bundle: nil)
 		let controller = storyboard.instantiateViewController(withIdentifier: "AltTextController") as! AltTextController
-		
+        controller.media = section.media[item]
 		self.present(controller, animated: true, completion: nil)
-
-		return
-		/*
-        self.altTextSection = section
-        self.altTextItem = item
-        self.view.bringSubviewToFront(self.altTextDialogView)
-        self.altTextDialogView.alpha = 0.0
-        self.altTextDialogView.isHidden = false
-        self.altTextTextView.text = section.media[item].altText
-
-        UIView.animate(withDuration: 0.15) {
-            self.altTextDialogView.alpha = 1.0
-        }
-
-        let currentAltText = section.media[item].altText
-        var saveTitle = "Add"
-        if currentAltText.count > 0 {
-            saveTitle = "Update"
-        }
-
-        self.altTextDoneButton.setTitle(saveTitle, for: .normal)
-        self.altTextTextView.becomeFirstResponder()
-		*/
     }
-
-
-
-    @IBAction func onAltTextCancel() {
-        UIView.animate(withDuration: 0.15) {
-            self.altTextDialogView.alpha = 0.0
-        }
-
-        self.altTextTextView.resignFirstResponder()
-    }
-
-    @IBAction func onAltTextDone() {
-
-        if let section = self.altTextSection {
-            section.media[self.altTextItem].altText = self.altTextTextView.text
-        }
-
-        UIView.animate(withDuration: 0.15) {
-            self.altTextDialogView.alpha = 0.0
-        }
-
-        self.altTextTextView.resignFirstResponder()
-    }
-
 	
 	/* ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 	MARK: -

--- a/Sunlit/Storyboards/Compose.storyboard
+++ b/Sunlit/Storyboards/Compose.storyboard
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21507" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21505"/>
         <capability name="Image references" minToolsVersion="12.0"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
@@ -34,7 +34,7 @@
                                 </constraints>
                             </view>
                             <view clipsSubviews="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="KSH-VH-Uxb">
-                                <rect key="frame" x="0.0" y="44" width="414" height="60"/>
+                                <rect key="frame" x="0.0" y="48" width="414" height="60"/>
                                 <subviews>
                                     <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="Title" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="a9n-oW-kej">
                                         <rect key="frame" x="16" y="8.5" width="382" height="43"/>
@@ -67,7 +67,7 @@
                                 </constraints>
                             </view>
                             <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="left" horizontalHuggingPriority="1000" horizontalCompressionResistancePriority="250" alwaysBounceVertical="YES" delaysContentTouches="NO" keyboardDismissMode="onDrag" dataMode="prototypes" prefetchingEnabled="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ehI-KN-yqo">
-                                <rect key="frame" x="0.0" y="104" width="414" height="714"/>
+                                <rect key="frame" x="0.0" y="108" width="414" height="710"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <collectionViewFlowLayout key="collectionViewLayout" automaticEstimatedItemSize="YES" minimumLineSpacing="0.0" minimumInteritemSpacing="0.0" id="iJd-OI-jXi">
                                     <size key="itemSize" width="128" height="128"/>
@@ -76,7 +76,7 @@
                                     <inset key="sectionInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
                                 </collectionViewFlowLayout>
                                 <cells>
-                                    <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" reuseIdentifier="PostTextCollectionViewCell" translatesAutoresizingMaskIntoConstraints="NO" id="rFM-lT-DzZ" customClass="PostTextCollectionViewCell" customModule="Sunlit" customModuleProvider="target">
+                                    <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" fixedFrame="YES" insetsLayoutMarginsFromSafeArea="NO" reuseIdentifier="PostTextCollectionViewCell" translatesAutoresizingMaskIntoConstraints="NO" id="rFM-lT-DzZ" customClass="PostTextCollectionViewCell" customModule="Sunlit" customModuleProvider="target">
                                         <rect key="frame" x="0.0" y="0.0" width="128" height="128"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <collectionViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" id="jdC-70-3Nt">
@@ -114,7 +114,7 @@
                                             <outlet property="widthConstraint" destination="HSD-uo-sTe" id="4CL-hp-XrX"/>
                                         </connections>
                                     </collectionViewCell>
-                                    <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="PostImageCollectionViewCell" translatesAutoresizingMaskIntoConstraints="NO" id="RRn-zX-YhQ" customClass="PostImageCollectionViewCell" customModule="Sunlit" customModuleProvider="target">
+                                    <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" fixedFrame="YES" reuseIdentifier="PostImageCollectionViewCell" translatesAutoresizingMaskIntoConstraints="NO" id="RRn-zX-YhQ" customClass="PostImageCollectionViewCell" customModule="Sunlit" customModuleProvider="target">
                                         <rect key="frame" x="147" y="4" width="120" height="120"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <collectionViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" id="Zi2-Jg-TIo">
@@ -151,7 +151,7 @@
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                             <subviews>
                                                 <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="9GI-cb-AlC">
-                                                    <rect key="frame" x="52" y="52" width="24.5" height="23.5"/>
+                                                    <rect key="frame" x="51.5" y="51" width="25.5" height="25.5"/>
                                                     <color key="tintColor" systemColor="labelColor"/>
                                                     <imageReference key="image" image="plus.circle" catalog="system" symbolScale="large"/>
                                                     <preferredSymbolConfiguration key="preferredSymbolConfiguration" weight="light"/>
@@ -189,7 +189,7 @@
                                                     </userDefinedRuntimeAttributes>
                                                 </view>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="New Section" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="GdF-Ro-omh">
-                                                    <rect key="frame" x="166.5" y="55.5" width="81.5" height="17"/>
+                                                    <rect key="frame" x="159" y="54" width="96.5" height="20.5"/>
                                                     <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
@@ -294,7 +294,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="KGh-Ef-hiJ">
-                                <rect key="frame" x="50" y="194" width="314" height="170"/>
+                                <rect key="frame" x="50" y="198" width="314" height="170"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Accessibility Description" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="bcO-S4-mf3">
                                         <rect key="frame" x="16" y="16" width="285" height="20.5"/>
@@ -345,8 +345,7 @@
                                         </constraints>
                                         <state key="normal" title="Add"/>
                                         <connections>
-                                            <action selector="done" destination="Vo1-M3-6Gq" eventType="touchUpInside" id="aLM-81-ljM"/>
-                                            <action selector="onAltTextDone" destination="Xuq-8W-x41" eventType="touchUpInside" id="RY9-mK-o5T"/>
+                                            <action selector="done" destination="Vo1-M3-6Gq" eventType="touchUpInside" id="LDQ-W3-kfb"/>
                                         </connections>
                                     </button>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="m9n-JR-P6a">
@@ -357,8 +356,7 @@
                                         <fontDescription key="fontDescription" type="system" pointSize="15"/>
                                         <state key="normal" title="Cancel"/>
                                         <connections>
-                                            <action selector="cancel" destination="Vo1-M3-6Gq" eventType="touchUpInside" id="EMw-iP-2FN"/>
-                                            <action selector="onAltTextCancel" destination="Xuq-8W-x41" eventType="touchUpInside" id="PfZ-Nn-gfs"/>
+                                            <action selector="cancel" destination="Vo1-M3-6Gq" eventType="touchUpInside" id="rok-qw-lJy"/>
                                         </connections>
                                     </button>
                                 </subviews>
@@ -406,6 +404,9 @@
                             <constraint firstItem="Gkh-yX-AiT" firstAttribute="trailing" secondItem="KGh-Ef-hiJ" secondAttribute="trailing" constant="50" id="g8f-Gx-4XJ"/>
                         </constraints>
                     </view>
+                    <connections>
+                        <outlet property="altTextTextView" destination="Hug-Mj-Z7L" id="pGF-md-x2N"/>
+                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="0QA-Tx-1Np" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
@@ -414,7 +415,7 @@
     </scenes>
     <resources>
         <image name="location" catalog="system" width="128" height="121"/>
-        <image name="plus.circle" catalog="system" width="128" height="121"/>
+        <image name="plus.circle" catalog="system" width="128" height="123"/>
         <namedColor name="color_alt_background">
             <color white="0.5" alpha="0.5" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </namedColor>
@@ -428,7 +429,7 @@
             <color white="0.69999998807907104" alpha="0.5" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </namedColor>
         <systemColor name="labelColor">
-            <color white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+            <color red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
         <systemColor name="secondarySystemBackgroundColor">
             <color red="0.94901960784313721" green="0.94901960784313721" blue="0.96862745098039216" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>


### PR DESCRIPTION
Add a media item reference to AltTextController and set it before showing the view. Use that item's alt text to initialize the text view and make it first responder when the controller's view is shown. Update the media item's alt text when the user selects the "Add" button. Also remove unused outlets and commented out code.

Tested by starting a new post, adding an image, and selecting the "Add Description" option for that image. Confirmed that the text is stored in the media item by entering some text, selecting "Add", and then re-selecting the "Add Description" option to see the same text. Confirmed that selecting "Cancel" leaves the text unchanged. Completed the post and confirmed that the text appears in the alt tag for the image.